### PR TITLE
v2: return default value if boolean is not set

### DIFF
--- a/v2/bool.go
+++ b/v2/bool.go
@@ -75,6 +75,8 @@ func (f *BoolField) Get() (bool, error) {
 	switch v {
 	case "1", trueValue, "yes":
 		return true, nil
+	case "":
+		return f.defaultValue, nil
 	default:
 		return false, nil
 	}

--- a/v2/bool_test.go
+++ b/v2/bool_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestBool(t *testing.T) {
 	var (
-		optional = env.Bool("OPTIONAL_FIELD", false)
+		optional = env.Bool("OPTIONAL_FIELD", true)
 		required = env.Bool("REQUIRED_FIELD", false, env.Required())
 	)
 
@@ -45,7 +45,7 @@ func TestBool(t *testing.T) {
 	}
 
 	t.Run("Value", testFn(optional, "1", true, nil))
-	t.Run("DefaultValue", testFn(optional, "", false, nil))
+	t.Run("DefaultValue", testFn(optional, "", true, nil))
 	t.Run("RequiredAndSet", testFn(required, "yes", true, nil))
 	t.Run("RequiredNotSet", testFn(required, "", false, env.ErrRequiredValueIsMissing))
 	t.Run("UnallowedValue", testFn(optional, "okaydokay", false, env.ErrValueIsNotAllowed))


### PR DESCRIPTION
If an environment variable of type boolean is not set, the default value always returned false. This commit should fix the issue.